### PR TITLE
Add status code/get call to SAI and children classes

### DIFF
--- a/drivers/SAI.cpp
+++ b/drivers/SAI.cpp
@@ -38,8 +38,11 @@ SAI::SAI(PinName mclk, PinName bclk, PinName wclk, PinName sd,
 
     init.format = *fmt;
 
-    if (sai_init(&_sai, &init) != SAI_RESULT_OK) {
+    _status = sai_init(&_sai, &init);
+
+    if (_status != SAI_RESULT_OK) {
         // it failed :o
+        printf("SAI init failed with: %d\r\n", _status);
     }
 }
 
@@ -48,6 +51,10 @@ bool SAI::xfer(uint32_t *value) {
     bool ret = sai_xfer(&_sai, value);
     unlock();
     return ret;
+}
+
+sai_result_t SAI::status(void) {
+    return _status;
 }
 
 void SAI::lock() {

--- a/drivers/SAI.h
+++ b/drivers/SAI.h
@@ -46,6 +46,11 @@ public:
      */
     virtual bool xfer(uint32_t *value);
 
+    /** Retreive the object status. Allows the ctor to
+     * funnel init errors/warnings back up to the application.
+     */
+    virtual sai_result_t status(void);
+
     /** Acquire exclusive access to this SAI bus
      */
     virtual void lock(void);
@@ -62,6 +67,7 @@ protected:
     sai_t           _sai;
     PlatformMutex   _mutex;
     bool            _is_input;
+    sai_result_t    _status;
 };
 
 class SAITransmitter : private SAI {
@@ -69,6 +75,10 @@ class SAITransmitter : private SAI {
         SAITransmitter(PinName mclk, PinName bclk, PinName wclk, PinName sd,
                        const sai_format_t *fmt = &sai_mode_i2s32)
            : SAI(mclk, bclk, wclk, sd, fmt, false) { }
+
+        sai_result_t status(void) {
+            return this->status();
+        }
 
         bool send(uint32_t sample) {
             return this->xfer(&sample);
@@ -80,6 +90,10 @@ class SAIReceiver : private SAI {
         SAIReceiver(PinName mclk, PinName bclk, PinName wclk, PinName sd,
                     const sai_format_t *fmt = &sai_mode_i2s32)
             : SAI(mclk, bclk, wclk, sd, fmt, true) { }
+
+        sai_result_t status(void) {
+            return this->status();
+        }
 
         bool receive(uint32_t *sample) {
             return this->xfer(sample);

--- a/drivers/SAI.h
+++ b/drivers/SAI.h
@@ -41,15 +41,18 @@ public:
         const sai_format_t *fmt = &sai_mode_i2s32, bool is_input = false,
         uint32_t master_clock = 0, bool internal_mclk = false);
 
-    /** Push a sample to the Fifo & try to read a new sample.
-     * it may return 0 if no sample was available.
-     */
-    virtual bool xfer(uint32_t *value);
-
     /** Retreive the object status. Allows the ctor to
      * funnel init errors/warnings back up to the application.
      */
     virtual sai_result_t status(void);
+
+    virtual ~SAI() {}
+
+protected:
+    /** Push a sample to the Fifo & try to read a new sample.
+     * it may return 0 if no sample was available.
+     */
+    virtual bool xfer(uint32_t *value);
 
     /** Acquire exclusive access to this SAI bus
      */
@@ -59,41 +62,29 @@ public:
      */
     virtual void unlock(void);
 
-
-public:
-    virtual ~SAI() {}
-
-protected:
+    ////////////////////////////////////////////
     sai_t           _sai;
     PlatformMutex   _mutex;
     bool            _is_input;
     sai_result_t    _status;
 };
 
-class SAITransmitter : private SAI {
+class SAITransmitter : public SAI {
     public:
         SAITransmitter(PinName mclk, PinName bclk, PinName wclk, PinName sd,
                        const sai_format_t *fmt = &sai_mode_i2s32)
            : SAI(mclk, bclk, wclk, sd, fmt, false) { }
-
-        sai_result_t status(void) {
-            return this->status();
-        }
 
         bool send(uint32_t sample) {
             return this->xfer(&sample);
         }
 };
 
-class SAIReceiver : private SAI {
+class SAIReceiver : public SAI {
     public:
         SAIReceiver(PinName mclk, PinName bclk, PinName wclk, PinName sd,
                     const sai_format_t *fmt = &sai_mode_i2s32)
             : SAI(mclk, bclk, wclk, sd, fmt, true) { }
-
-        sai_result_t status(void) {
-            return this->status();
-        }
 
         bool receive(uint32_t *sample) {
             return this->xfer(sample);


### PR DESCRIPTION
SAI inheritance is private to children classes to protect internal calls hence the duplicate status functions in each child class.
_______________________
 **NOTE** 
Second commit invalidates the above statement. Will squash to one commit when we resolve what's the best inheritance structure for the Transmitter/Receiver children classes.