### PR TITLE
K64F, K66F: Remove "FLASHIAP" component.

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1353,7 +1353,7 @@
     },
     "K64F": {
         "supported_form_factors": ["ARDUINO"],
-        "components_add": ["FLASHIAP"],
+        "components_add": [],
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": [
@@ -1364,8 +1364,7 @@
             "KPSDK_MCUS",
             "KPSDK_CODE",
             "MCU_K64F",
-            "Freescale_EMAC",
-            "PSA"
+            "Freescale_EMAC"
         ],
         "is_disk_virtual": true,
         "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "MBEDTLS_PSA_CRYPTO_C"],
@@ -1639,7 +1638,7 @@
     },
     "K82F": {
         "supported_form_factors": ["ARDUINO"],
-        "components_add": ["FLASHIAP"],
+        "components_add": [],
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": ["Freescale", "MCUXpresso_MCUS", "KSDK2_MCUS", "FRDM"],


### PR DESCRIPTION
### Description

When "SD" component is unavailable on `K64F` and `K82F` the following tests try to use Flash as storage and fail:
`features-storage-tests-blockdevice-general_block_device`
`features-device_key-tests-device_key-functionality`
`features-storage-tests-kvstore-static_tests`
`features-storage-tests-kvstore-general_tests_phase_1`
`features-storage-tests-kvstore-securestore_whitebox`
`tests-psa-prot_internal_storage`

This PR disables "FLASHIAP" component for `K64F` and `K82F` (and PSA for `K64F` since the `tests-psa-prot_internal_storage` test requires storage).
Additional investigation is required to find the reason of the failures.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

